### PR TITLE
Disable Style/Documentation and Style/FrozenStringLiteralComment.

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -127,6 +127,12 @@ RSpec/VerifiedDoubles:
 Style/ClassCheck:
   Enabled: false
 
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/Lambda:
   EnforcedStyle: literal
 

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.1.1'.freeze
   end
 end


### PR DESCRIPTION
* `Style/Documentation` wants every module/class to start with a doc comment. This is not a pattern we've ever followed.

* `Style/FrozenStringLiteralComment` is annoying and we don't use it anywhere, we should tackle that if/when we upgrade to Ruby 3.
