### PR TITLE
Disable Style/SymbolProc cop

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -145,6 +145,9 @@ Style/NumericPredicate:
 Style/StringLiterals:
   Enabled: false
 
+Style/SymbolProc:
+  Enabled: false
+
 Style/TernaryParentheses:
   Enabled: false
   

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.1.2'.freeze
+    VERSION = '0.1.3'.freeze
   end
 end


### PR DESCRIPTION
Rubocop wants to enforce the following:

```
# bad
something.map { |s| s.upcase }

# good
something.map(&:upcase)
```

Whether or not we like that enforcement (I'm not sure I do), it unfortunately causes issues when block parameters are optionally provided. In other words, if the `s` parameter above, is only optionally provided when specified, then the second form will throw an `ArgumentError: no receiver given`.

Googling netted someone with the same experience [here](https://github.com/thoughtbot/factory_girl/issues/698)

I think we should just leave this transformation up to our own judgement, especially given that it can force us to write a line which fails at run time.