### PR TITLE
Increase RSpec/NestedGroups [Max] to 4

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -145,6 +145,9 @@ RSpec/EmptyLineAfterSubject:
 RSpec/ExampleLength:
   Enabled: false
 
+RSpec/NestedGroups:
+  Max: 4
+
 RSpec/Focused:
   Enabled: true
 

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.2.0'.freeze
+    VERSION = '0.2.1'.freeze
   end
 end


### PR DESCRIPTION
Rubocop wants us to keep nesting within specs to a max of 3 levels. I agree that avoiding too much nesting is good because it can lead to a hard to understand spec, but I think 3 is just a bit too low. I've run into this cop multiple times and I felt it actually made the specs a little worse after flattening them out.

I'd like to bump it up just a little to 4. It allows for a typical structure like:

```
describe Something do # level 1
  context "#some_method" do # level 2
    context "some situation" do # level 3
      context "some sub situation do # level 4 - this currently isn't allowed
         it ...
      end
    end
  end
end
```

I think it's common enough to have some kind of "sub situation" like this that would make it nice to be able to make another level of context nesting to organize it. I can also see that even just one more level might be a reasonable point at which it's crossed over to being hard to comprehend. That's why I think 4 might be good, at least for now.