### PR TITLE
Disable a collection of rules.

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -145,11 +145,11 @@ RSpec/EmptyLineAfterSubject:
 RSpec/ExampleLength:
   Enabled: false
 
-RSpec/NestedGroups:
-  Max: 4
-
 RSpec/Focused:
   Enabled: true
+
+RSpec/LeadingSubject:
+  Enabled: false
 
 RSpec/MessageSpies:
   Enabled: false
@@ -157,8 +157,14 @@ RSpec/MessageSpies:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/NestedGroups:
+  Enabled: false
+
 RSpec/NotToNot:
   EnforcedStyle: to_not
+
+RSpec/ScatteredLet:
+  Enabled: false
 
 RSpec/ScatteredSetup:
   Enabled: false
@@ -182,6 +188,9 @@ Style/MultilineBlockChain:
   Enabled: false
 
 Style/NumericPredicate:
+  Enabled: false
+
+Style/RegexpLiteral:
   Enabled: false
 
 Style/StringLiterals:

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.2'.freeze
   end
 end


### PR DESCRIPTION
This disables a collection of rules that I found to be counterproductive when doing some cleanup.

* `RSpec/LeadingSubject` - Errors if you have a `subject` after a `let` in a test. I don't think this adds much to readability and can hurt it. It can be much more readable to do your setup with `let`s and then end with a `subject` that consumes them.

* `RSpec/NestedGroups` - Errors if you have too many nested `context` blocks. We had previously raised the max to 4 but I think we should just disable it. I have never seen a case where refactoring nested context blocks actually creates a better test in practice; I currently have a test that's 5 deep that I don't think should be refactored so I think we'll just end up bumping it higher and higher.

* `RSpec/ScatteredLet` - Errors if you don't have all of your `let`s in one cluster. I think this can add a bit to readability but sometimes it's easier to tell the story of the test by splitting it up with `before`s or other things. Also it's annoying and I don't want it to discourage more testwriting.

* `Style/RegexpLiteral` - Wants you to use `%r{}` for regular expressions (instead of `//` etc). I don't know how this helps anything and it's annoying because it's an unusual syntax.