### PR TITLE
Disable Layout/TrailingWhitespace, set Style/ClassAndModuleChildren to compact

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -76,6 +76,9 @@ Layout/MultilineMethodDefinitionBraceLayout:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
+Layout/TrailingWhitespace:
+  Enabled: false
+
 Lint/BlockAlignment:
   EnforcedStyleAlignWith: start_of_block
   
@@ -172,10 +175,16 @@ RSpec/ScatteredSetup:
 RSpec/VerifiedDoubles:
   Enabled: false
 
+Style/ClassAndModuleChildren:
+  EnforcedStyle: compact
+
 Style/ClassCheck:
   Enabled: false
 
 Style/Documentation:
+  Enabled: false
+
+Style/EachWithObject:
   Enabled: false
 
 Style/FrozenStringLiteralComment:
@@ -209,7 +218,4 @@ Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/WordArray:
-  Enabled: false
-
-Style/EachWithObject:
   Enabled: false

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.2.2'.freeze
+    VERSION = '0.2.3'.freeze
   end
 end


### PR DESCRIPTION
* Disable Layout/TrailingWhitespace as we've decided that the cost of polluted blames is not worth the benefit of fixing existing violations.

* Set Style/ClassAndModuleChildren to compact to better match our existing code. Enforces the following:

```ruby
# bad
module SomeModule
  class SomeClass
  end
end

# good
class SomeModule::SomeClass
end
```
* Move Style/EachWithObject into alphabetical position