### PR TITLE
Disable the RSpec/PredicateMatcher

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -166,6 +166,9 @@ RSpec/NestedGroups:
 RSpec/NotToNot:
   EnforcedStyle: to_not
 
+RSpec/PredicateMatcher:
+  Enabled: false
+
 RSpec/ScatteredLet:
   Enabled: false
 

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.2.3'.freeze
+    VERSION = '0.2.4'.freeze
   end
 end


### PR DESCRIPTION
[Aha feature](https://big.aha.io/features/APP-5295)

`RSpec/PredicateMatcher` enforces `expect(object) to
be_boolean_attribute` instead of `expect(object.boolean_attribute?)`

This reads better with some of the Ruby built-ins, but makes Rails'
auto-generated boolean fields read worse. We shouldn't have a strict
preference for style for this one.