### PR TITLE
Configure Layout/SpaceInLambdaLiteral to require_space

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -79,6 +79,9 @@ Layout/MultilineMethodDefinitionBraceLayout:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
+Layout/SpaceInLambdaLiteral:
+  EnforcedStyle: require_space
+
 Layout/TrailingWhitespace:
   Enabled: false
 

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.2.5'.freeze
+    VERSION = '0.2.6'.freeze
   end
 end


### PR DESCRIPTION
The default wants:

```ruby
a = ->(x, y) { x + y }
```

This change instead enforces:

```ruby
a = -> (x, y) { x + y }
```

which is how the vast majority of our existing lambdas are spaced.