### PR TITLE
Enable Layout/MultilineAssignmentLayout

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -64,6 +64,9 @@ Layout/IndentHash:
 Layout/MultilineArrayBraceLayout:
   EnforcedStyle: new_line
 
+Layout/MultilineAssignmentLayout:
+  Enabled: true
+
 Layout/MultilineHashBraceLayout:
   EnforcedStyle: new_line
 

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.2.6'.freeze
+    VERSION = '0.2.7'.freeze
   end
 end


### PR DESCRIPTION
Enforces that multiline assignments begin on a new line.

```ruby
# bad
foo = if expression
  'bar'
else
  'baz'
end

# good
foo =
  if expression
    'bar'
  else
    'baz'
  end
```

I am not strongly opinionated about this particular cop, but it does keep the lines clean and easy to follow. Also, in combination with the rest of our configuration, it makes it a lot easier to get a sane result out of autocorrect. Otherwise, sometimes this happens:

```ruby
class SomeClass
  def some_method
    foo = if expression
      'bar'
          else
            'baz'
          end
  end
end
```
because it wants to line up the `if`s and `else`s and it also wants to have new lines indented by 2 spaces past the previous line and those two things can be in conflict.