### PR TITLE
Disable Style/Next

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -205,6 +205,9 @@ Style/Lambda:
 Style/MultilineBlockChain:
   Enabled: false
 
+Style/Next:
+  Enabled: false
+
 Style/NumericPredicate:
   Enabled: false
 


### PR DESCRIPTION
This cop seems to just prefer using guard statements inside of blocks instead of if statements. Seemed worth disabling—we have enough discretion to know what to use.
  
This cop tried to force this:

```ruby
if epic.save && epic_params[:move_to_release] == "true"
  epic.features.each do |feature|
    feature.update_attribute(:release_id, release_id)
  end
end
```

Into this:

```ruby
next unless epic.save && epic_params[:move_to_release] == "true"

epic.features.each do |feature|
  feature.update_attribute(:release_id, release_id)
end
```