### PR TITLE
disabling the casecmp cop

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -237,3 +237,6 @@ Style/TrailingCommaInHashLiteral:
 
 Style/WordArray:
   Enabled: false
+
+Performance/Casecmp:
+  Enabled: false


### PR DESCRIPTION
Reference: http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Performance/Casecmp