### PR TITLE
Use Weirich Brace Convention for block delimiters

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -184,6 +184,9 @@ RSpec/ScatteredSetup:
 RSpec/VerifiedDoubles:
   Enabled: false
 
+Style/BlockDelimiters:
+  EnforcedStyle: semantic
+
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 


### PR DESCRIPTION
The `do/end` vs. `{}` rule for single- vs. multi-line blocks requires rewriting
whenever the code in the block changes for unrelated reasons.

Instead, [a more consistent rule][1] exists to indicate the purpose of the block:

[1]: http://www.virtuouscode.com/2011/07/26/the-procedurefunction-block-convention-in-ruby/

- Use `{}` for FUNCTIONAL blocks -- when the return value of the block is used
- Use `do/end` for PROCEDURAL blocks -- when the return value is discarded

This makes chaining of blocks more natural with the `{}` syntax, whether they
span over multiple lines or not.

It also works out that (a lot of the time) one-liners are functional while
procedures span over lines, so it looks almost the same as the line-number rule.

Specific methods are predefined as ProceduralMethods (`each`, `before`,
`configure`, etc.) or FunctionalMethods (`map`, `select`, `let`, etc.) and can
be configured to add more if needed.