### PR TITLE
Allow setting up mocks in before blocks

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -154,6 +154,9 @@ RSpec/EmptyLineAfterSubject:
 RSpec/ExampleLength:
   Enabled: false
 
+RSpec/ExpectInHook:
+  Enabled: false
+
 RSpec/Focused:
   Enabled: true
 


### PR DESCRIPTION
This rule prevents setting up test spies & method stubs in before blocks.

Test setup like this should be possible without repeating in every example:

```
before do
  expect(subject).to_not receive(:external_api_call)
end

it "does other stuff" do
  # ...
end
```