### PR TITLE
Disable the symbol array check

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -240,3 +240,6 @@ Style/WordArray:
 
 Performance/Casecmp:
   Enabled: false
+
+Style/SymbolArray:
+  Enabled: false

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.3.0'.freeze
+    VERSION = '0.4.0'.freeze
   end
 end


### PR DESCRIPTION
Disable style requiring `[:a, :b, :c]` to be `%i(a b c)`

It seems like people prefer to use symbol arrays when they are small and I don't think the %i() syntax makes life any better.