### PR TITLE
disable Style/NumericLiterals cop

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -211,6 +211,9 @@ Style/MultilineBlockChain:
 Style/Next:
   Enabled: false
 
+Style/NumericLiterals:
+  Enabled: false
+
 Style/NumericPredicate:
   Enabled: false
 

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.4.0'.freeze
+    VERSION = '0.4.1'.freeze
   end
 end


### PR DESCRIPTION
I'm surprised that we've avoided this one so far. Here's the documentation: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NumericLiterals

I don't see any point in keeping this. It recently complained about a line where I hardcoded an ID in a spec. For example:

`expect(id).to eq 12345`

would need to be changed to:

`expect(id).to eq 12_345`

Yeah, no.