### PR TITLE
Disable RSpec/ContextWording

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -148,6 +148,9 @@ Rails/SkipsModelValidations:
 RSpec/BeEql:
   Enabled: false
 
+RSpec/ContextWording:
+  Enabled: false
+
 RSpec/EmptyLineAfterSubject:
   Enabled: false
 


### PR DESCRIPTION
IMO it is not a good practice to enforce language with superfluous words
which is contextual (hah) and not correctable.