### PR TITLE
Only check and/or in conditionals

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -252,3 +252,6 @@ Performance/Casecmp:
 
 Style/SymbolArray:
   Enabled: false
+
+Style/AndOr:
+  EnforcedStyle: conditionals


### PR DESCRIPTION
The AndOr cop https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/AndOr is preventing us from writing `statement or raise 'error'`.