### PR TITLE
Disable Lint/AssignmentInCondition

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -253,5 +253,8 @@ Performance/Casecmp:
 Style/SymbolArray:
   Enabled: false
 
+Lint/AssignmentInCondition:
+  Enabled: false
+
 Style/AndOr:
   EnforcedStyle: conditionals

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.4.1'.freeze
+    VERSION = '0.4.3'.freeze
   end
 end


### PR DESCRIPTION
This one goes hand in hand with https://github.com/aha-app/rubocop-aha/pull/24.  I'd like to also be able manage flow by being able to do assignment in the conditional.

```
if a = b.fetch(:test, nil)
  a
else
  raise BadError
end
```