### PR TITLE
Disable Style/EmptyMethod

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -202,6 +202,9 @@ Style/Documentation:
 Style/EachWithObject:
   Enabled: false
 
+Style/EmptyMethod:
+  Enabled: false
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 


### PR DESCRIPTION
Allow writing empty methods with `end` on its own line.

“Put empty method definitions on a single line” is at cross-purposes with:

- Put a comma after the last parameter of a multiline method call
- Put a comma after the last item of a multiline hash

Since the goal with the trailing commas is to make it easy to add things without
changing previous lines, then the “single line” empty method definitions do the
opposite of that.