### PR TITLE
Allow for underscores in numbered variable names

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -244,6 +244,9 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
+Style/VariableNumber:
+  Enabled: false
+
 Style/WordArray:
   Enabled: false
 


### PR DESCRIPTION
If a few variables need numbering, it should not be required to name them a
certain way. In fact, for multi-word variable names, it makes more sense to
allow for a separator before the number when there are intra-word spaces:

    my_model_1 = one
    my_model_2 = two

Rubocop would have you write this as `my_model1` which reads like we are dealing
with some kind of "model1", when in fact the important tokens in that name are
`my_model` and `1`.