### PR TITLE
Allow for methods with more keyword arguments

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -124,6 +124,9 @@ Metrics/MethodLength:
 Metrics/ModuleLength:
   Enabled: false
 
+Metrics/ParameterLists:
+  CountKeywordArgs: false
+
 Metrics/PerceivedComplexity:
   Enabled: false
 


### PR DESCRIPTION
(Rails itself also has several methods that just take an "options" hash...)

We should use our judgment on what is too many parameters, but this should not
restrict us when it does make sense to have named options on helper methods.

This is also a solution for something I couldn't resolve: pronto is complaining about this on a couple spec helper methods, but rubocop doesn’t see the same failure in CI. Adding a `rubocop:disable` for this just causes it to complain the other way that it's an "unnecessary disabling".

There might be a more fundamental configuration fix to get these tools to agree, but after discussing this it sounds like we could just disable it. Instead of fully disabling it, ~this just allows for named arguments instead.~

EDIT: this now allows for unlimited positional arguments, too.