### PR TITLE
Allow for block delimiters that make sense based on context

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -196,6 +196,9 @@ RSpec/ScatteredSetup:
 RSpec/VerifiedDoubles:
   Enabled: false
 
+Style/BlockDelimiters:
+  Enabled: false
+
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 


### PR DESCRIPTION
Don't enforce a particular style for block delimiters, whether single- or multi-
line. This allows for better readability when chaining blocks, and consistency
when defining a group of DSL blocks (e.g. rspec `let` when some are single- and
others are multi-line).

Follows from the discussion in #18.