### PR TITLE
Don't enforce if/unless to be used as a trailing modifier

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -214,6 +214,9 @@ Style/EmptyMethod:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Style/Lambda:
   EnforcedStyle: literal
 


### PR DESCRIPTION
This rule is already disabled in aha-services-2, so this is an attempt to standardize our rules between repositories.

When a statement is shown as one long line, it is often more readable to have
the condition stated separately, up front, instead of having to look over to the
end of a long line.

It may also help to break up complex statements into one condition line, and one
statement line for easier debugging.

This leaves it up to the author's discretion whether a condition makes more
sense as a trailing modifier or a block based on context.