### PR TITLE
Don't enforce style of module declaration

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -197,7 +197,7 @@ RSpec/VerifiedDoubles:
   Enabled: false
 
 Style/ClassAndModuleChildren:
-  EnforcedStyle: compact
+  Enabled: false
 
 Style/ClassCheck:
   Enabled: false


### PR DESCRIPTION
The nested style allows deeply-nested modules to be reopened and still access
other constants that are declared in the same namespace without needing to use
absolute `::` top-level addressing:

    module TopLevel
      Base = Class.new
    end

    module TopLevel
      class SecondLevel < Base  # instead of ::TopLevel::Base
      end
    end

The compact style is useful when the expected nesting is already loaded and
defined, so the types of the nesting objects don't need to be re-declared:

    class Example < ActiveModel::Base
    end

    module Example::Helpers
      # instead of re-declaring the class inheritance of Example
    end

Sometimes a combination is warranted, with the top-level namespace module
explicitly defined as a catch-all for constant lookup. The rules for declaring a
new object under a Module vs. a Class should not be enforced differently.
