### PR TITLE
Don't specify StandardError when you mean "all reasonable errors"

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -235,6 +235,9 @@ Style/ParallelAssignment:
 Style/RegexpLiteral:
   Enabled: false
 
+Style/RescueStandardError:
+  EnforcedStyle: implicit
+
 Style/StringLiterals:
   Enabled: false
 


### PR DESCRIPTION
StandardError exists in ruby as a default baseline for rescuing errors and
shouldn't need to be specified when you just want to rescue anything.

Classes outside of StandardError are system errors, which shouldn't ever be
rescued unless you really know what you're doing. These should be specified only
when absolutely needed.

Subclasses of StandardError are more specific types of application errors
that may be specified when needed.

Requiring an exception class to be named for every rescue block means giving up
the convention of a default baseline for normally-rescuable errors.

Hence, exception classes should only be specified when they are meaningful:
when it is known that only specific types of errors should be rescued, and only
then be highlighted as such.