### PR TITLE
Avoid being more abstract than necessary in RSpec

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -157,6 +157,9 @@ RSpec/BeEql:
 RSpec/ContextWording:
   Enabled: false
 
+RSpec/DescribedClass:
+  Enabled: false
+
 RSpec/EmptyLineAfterSubject:
   Enabled: false
 


### PR DESCRIPTION
Using `described_class` instead of the actual class name is often unnecessary,
unless you actually need to metaprogram your tests. This makes things harder to
search for and understand at a glance.

(Also, sometimes it's a module and not a class.)