### PR TITLE
Revert "Don't specify StandardError when you mean "all reasonable errors""

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -244,9 +244,6 @@ Style/ParallelAssignment:
 Style/RegexpLiteral:
   Enabled: false
 
-Style/RescueStandardError:
-  EnforcedStyle: implicit
-
 Style/StringLiterals:
   Enabled: false
 


### PR DESCRIPTION
Reverts aha-app/rubocop-aha#33

Two things:
1. We need to update the app for rubocop to pass or update, and I’m not sure we should now.
2. After seeing what it’s asking in practice, I’m not sure about this one and I think it warrants further discussion because I like the idea of being explicitly forced to think about which exception you want to rescue.