### PR TITLE
Add staging to the list of allowed environments

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -276,3 +276,10 @@ Style/AndOr:
 
 Style/GuardClause:
   Enabled: false
+
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - development
+    - test
+    - staging


### PR DESCRIPTION
By default only development, test and production are allowed