### PR TITLE
Disable Layout/EmptyLinesAroundModuleBody

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -49,6 +49,9 @@ Layout/EmptyLinesAroundClassBody:
 Layout/EmptyLinesAroundExceptionHandlingKeywords:
   Enabled: false
 
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+
 Layout/EndAlignment:
   EnforcedStyleAlignWith: variable
 


### PR DESCRIPTION
The other layout items for classes and other types of blocks are already
disabled, this makes modules consistent with the rest.

Reason one, this allows for method comments to not be jammed up against the
containing module at the top:

    module Example

      # this describes the method, not the module above
      def example
      end
    end

Reason two, this allows for separation between nesting levels to spot where
methods vs. modules end at the bottom, instead of having the staircase of `end`s
jammed together:

    module Example
      module Component
        module Functionality

          def example
          end

        end
      end
    end