### PR TITLE
Disable trailing comma in arguments

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -256,9 +256,6 @@ Style/SymbolProc:
 Style/TernaryParentheses:
   Enabled: false
   
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: comma
-
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 

--- a/lib/config.yml
+++ b/lib/config.yml
@@ -256,6 +256,9 @@ Style/SymbolProc:
 Style/TernaryParentheses:
   Enabled: false
   
+Style/TrailingCommaInArguments:
+  Enabled: false
+
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 


### PR DESCRIPTION
We don't do this in JavaScript, why do it in Ruby?

The default here is "no_comma".

Trailing commas can make sense for collection values like hashes and arrays so
that appending values only shows the addition of one line in diffs. However,
method arguments are not something that is typically expected to append more
values, and allowing for infinite arguments is not something we should promote
in our default style.