### PR TITLE
Enforce indentation, but don't enforce deep indentation.

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -83,7 +83,7 @@ Layout/MultilineMethodCallBraceLayout:
   EnforcedStyle: new_line
 
 Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented_relative_to_receiver
+  EnforcedStyle: indented
 
 Layout/MultilineMethodDefinitionBraceLayout:
   EnforcedStyle: new_line
@@ -279,6 +279,3 @@ Style/AndOr:
 
 Style/GuardClause:
   Enabled: false
-
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented

--- a/lib/config.yml
+++ b/lib/config.yml
@@ -279,3 +279,6 @@ Style/AndOr:
 
 Style/GuardClause:
   Enabled: false
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.4.2'.freeze
+    VERSION = '0.4.3'.freeze
   end
 end


### PR DESCRIPTION
Often I break down long lines via:

```
foo_bar = baz_qux
  .action_with_a_fairly_long_method_name1
  .action_with_a_fairly_long_method_name2
  .action_with_a_fairly_long_method_name3
```
I feel that this is easier to read and breaks each action into logical steps.  Bonus, it helps with long lines.  However, with the default rule of `aligned`, the above would instead be

```
foo_bar = baz_qux
            .action_with_a_fairly_long_method_name1
            .action_with_a_fairly_long_method_name2
            .action_with_a_fairly_long_method_name3
```
This encourages long lines, one of the problems I'm trying to solve with method chaining on mulitple lines.