### PR TITLE
Fix rule name: DescribeClass not DescribedClass

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -160,7 +160,7 @@ RSpec/BeEql:
 RSpec/ContextWording:
   Enabled: false
 
-RSpec/DescribedClass:
+RSpec/DescribeClass:
   Enabled: false
 
 RSpec/EmptyLineAfterSubject:


### PR DESCRIPTION
Rubocop ignores rule names that it doesn't recognize.