### PR TITLE
We want to disable both DescribeClass and DescribedClass

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -163,6 +163,9 @@ RSpec/ContextWording:
 RSpec/DescribeClass:
   Enabled: false
 
+RSpec/DescribedClass:
+  Enabled: false
+
 RSpec/EmptyLineAfterSubject:
   Enabled: false
 


### PR DESCRIPTION
- DescribeClass allows us to just say `describe "something"`

- DescribedClass allows us to use the actual class instead of the meta
  `described_class` method and avoid unnecessary abstraction in tests.