### PR TITLE
Allow using _ as a block or method parameter name.

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -133,6 +133,12 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Naming/UncommunicativeBlockParamName:
+  AllowedNames: _
+
+Naming/UncommunicativeMethodParamNam:
+  AllowedNames: io, id, to, by, on, in, at, _
+
 Naming/PredicateName:
   Enabled: false
 


### PR DESCRIPTION
It's a common idiom in ruby to use `_` as the name of an unused method parameter, but rubocop by default won't allow this because it's not 3 characters long.