### PR TITLE
Update rubocop-rspec dependency & new rules

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -184,6 +184,9 @@ RSpec/ExpectInHook:
 RSpec/Focused:
   Enabled: true
 
+RSpec/ImplicitSubject:
+  EnforcedStyle: single_line_only
+
 RSpec/LeadingSubject:
   Enabled: false
 

--- a/rubocop-aha.gemspec
+++ b/rubocop-aha.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rubocop', '>= 0.55.0'
 
-  spec.add_dependency 'rubocop-rspec', '~> 1.25.1'
-  spec.add_dependency 'rubocop-rspec-focused', '~> 1.0.0'
+  spec.add_dependency 'rubocop-rspec', '>= 1.25.1'
+  spec.add_dependency 'rubocop-rspec-focused', '>= 1.0.0'
 end


### PR DESCRIPTION
Updating rubocop-rspec adds some new rules. Not all of them are desirable.

This allows the new [RSpec/ImplicitSubject](https://rubocop-rspec.readthedocs.io/en/latest/cops_rspec/#rspecimplicitsubject) rule for one-liners.