### PR TITLE
Reduce the minimum allowed param length from 3 to 2

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -133,11 +133,8 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-Naming/UncommunicativeBlockParamName:
-  AllowedNames: _
-
 Naming/UncommunicativeMethodParamName:
-  AllowedNames: io, id, to, by, on, in, at, _
+  MinNameLength: 2
 
 Naming/PredicateName:
   Enabled: false


### PR DESCRIPTION
When the author provides more than one character for a param name, it indicates
that they have at least put some thought into it. This allows more 2 letter
names such as "op", "db", etc.

The override for block param names is removed because the default there is 1
character and it's redundant.