### PR TITLE
The nameless method param `_` still needs to be allowed

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -135,6 +135,7 @@ Metrics/PerceivedComplexity:
 
 Naming/UncommunicativeMethodParamName:
   MinNameLength: 2
+  AllowedNames: _
 
 Naming/PredicateName:
   Enabled: false


### PR DESCRIPTION
This was just removed, but apparently rubocop doesn't include `_` as a default allowed param name when defining subclass methods with unused params.