### PR TITLE
Disable RSpec/ImplicitSubject

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -183,7 +183,7 @@ RSpec/Focused:
   Enabled: true
 
 RSpec/ImplicitSubject:
-  EnforcedStyle: single_line_only
+  Enabled: false
 
 RSpec/LeadingSubject:
   Enabled: false


### PR DESCRIPTION
This is one of those rules that is good to follow as a rule of thumb, but should
not be enforced. It should be possible to write a single-line spec that also has
a description (or including a simple setup) without forcing it on one line:

    it "is the answer"
      is_expected.to eq 42
    end

This is fine. However, please avoid using implicit subject in complex examples
with multiple variables, where the actual subject is unclear from the
surrounding context.