### PR TITLE
IM-611 Update rubocop dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ inherit_gem:
   rubocop-aha: lib/config.yml
 ```
 
+## Semantic Versioning
+
+MAJOR version is currently 0: this is unspecified.
+
+MINOR version will update for breaking changes to rubocop, e.g. when existing
+rules break compatibility.
+
+PATCH version should be updated for new configuration changes that add more
+restrictive rules, and cause failures in client code.
+
 ## Contributing
 
 We are unlikely to accept external contributions to change configuration rules. You are welcome to fork or extend for your own purposes if you like the baseline but disagree with some of our settings. :)

--- a/lib/config.yml
+++ b/lib/config.yml
@@ -67,10 +67,10 @@ Layout/FirstMethodArgumentLineBreak:
 Layout/FirstMethodParameterLineBreak:
   Enabled: true
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 
 Layout/MultilineArrayBraceLayout:

--- a/lib/config.yml
+++ b/lib/config.yml
@@ -143,12 +143,6 @@ Naming/PredicateName:
 Naming/VariableNumber:
   Enabled: false
 
-Performance/StringReplacement:
-  Enabled: false
-
-Performance/TimesMap:
-  Enabled: false
-
 Rails/HttpPositionalArguments:
   Enabled: false
 
@@ -276,9 +270,6 @@ Style/TrailingCommaInHashLiteral:
   Enabled: false
 
 Style/WordArray:
-  Enabled: false
-
-Performance/Casecmp:
   Enabled: false
 
 Style/SymbolArray:

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.4.3'.freeze
+    VERSION = '0.5.0'.freeze
   end
 end

--- a/rubocop-aha.gemspec
+++ b/rubocop-aha.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.55.0'
+  spec.add_runtime_dependency 'rubocop', '>= 0.68.0'
 
   spec.add_dependency 'rubocop-rspec', '>= 1.25.1'
   spec.add_dependency 'rubocop-rspec-focused', '>= 1.0.0'


### PR DESCRIPTION
Bump version of rubocop to the latest.

This removes some obsolete rules, and renames some according to upstream.

Here I've defined a versioning strategy for this gem: if we change a rule (either ourselves or from upstream) in a way that is more restrictive on our codebase, the version should be updated appropriately.