### PR TITLE
Allow describing specs as how they "should" behave

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -170,6 +170,9 @@ RSpec/EmptyLineAfterSubject:
 RSpec/ExampleLength:
   Enabled: false
 
+RSpec/ExampleWording:
+  Enabled: false
+
 RSpec/ExpectInHook:
   Enabled: false
 


### PR DESCRIPTION
It does not change a thing whether we describe our specs with "should" or "must"
or "is expected to". Leave some room for natural language in descriptions.

```
it "should be allowed" do
  # RSpec/ExampleWording: Do not use should when describing your tests.
end
```