### PR TITLE
Make new AlignArguments rule work the same as AlignParameters

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -22,6 +22,9 @@ Bundler/OrderedGems:
 Capybara/FeatureMethods:
   Enabled: false
 
+Layout/AlignArguments:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 


### PR DESCRIPTION
This configures a rule that was recently introduced by rubocop to match another existing rule.

Layout rules for calling & declaring methods should work the same way. This
allows DSL methods to be declared with indented line continuation (2 spaces),
without needing to wrap everything in parentheses.

    # good:
    attr_accessible :one, :two
      :three, :four
