### PR TITLE
Disable RescuedExceptionsVariableName, we already ignore it all over the place

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -146,6 +146,9 @@ Naming/PredicateName:
 Naming/VariableNumber:
   Enabled: false
 
+Name/RescuedExceptionsVariableName:
+  Enabled: false
+
 Rails/HttpPositionalArguments:
   Enabled: false
 


### PR DESCRIPTION
I'd like to call the variable what I want. error, not e