### PR TITLE
Disable RSpec/RepeatedExample due to clash with

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -206,6 +206,9 @@ RSpec/NotToNot:
 RSpec/PredicateMatcher:
   Enabled: false
 
+RSpec/RepeatedExample:
+  Enabled: false
+
 RSpec/ScatteredLet:
   Enabled: false
 


### PR DESCRIPTION
We use the with() helper which creates context blocks. Rubocop doesn't
detect that these are context blocks, and so it complains about repeated
examples