### PR TITLE
Allow more flexibility to set up test models

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -149,8 +149,18 @@ Naming/VariableNumber:
 Naming/RescuedExceptionsVariableName:
   Enabled: false
 
+# Allow ad-hoc test models to use bare ActiveRecord::Base
+Rails/ApplicationRecord:
+  Exclude:
+    - "spec/**/*.rb"
+
 Rails/HttpPositionalArguments:
   Enabled: false
+
+# Allow ad-hoc test models to be referenced by class instance
+Rails/ReflectionClassName:
+  Exclude:
+    - "spec/**/*.rb"
 
 Rails/RequestReferer:
   EnforcedStyle: referrer


### PR DESCRIPTION
In spec directory only, disable warnings for:

> Models should subclass `ApplicationRecord`

Defining an isolated model in the test suite should not require all of
ApplicationRecord. Sometimes we want to unit test ActiveRecord extensions
without requiring our application extras.

In spec directory only, disable warnings for:

> Use a string value for `class_name`

Defining isolated isolated models under a test module should allow us to
reference these ad-hoc classes directly in-place for ActiveRecord associations
without needing to express it as a fully-qualified module string to be loaded.