### PR TITLE
CN-211: Disable Rails/HelperInstanceVariable rubocop rule

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -118,8 +118,8 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: true
 
-Metrics/AbcSize: 
-  Enabled: false 
+Metrics/AbcSize:
+  Enabled: false
 
 Metrics/BlockLength:
   Enabled: false
@@ -175,6 +175,9 @@ Rails/RequestReferer:
   EnforcedStyle: referrer
 
 Rails/SkipsModelValidations:
+  Enabled: false
+
+Rails/HelperInstanceVariable:
   Enabled: false
 
 RSpec/BeEql:
@@ -278,7 +281,7 @@ Style/NumericPredicate:
 
 Style/ParallelAssignment:
   Enabled: false
-  
+
 Style/RegexpLiteral:
   Enabled: false
 
@@ -290,7 +293,7 @@ Style/SymbolProc:
 
 Style/TernaryParentheses:
   Enabled: false
-  
+
 Style/TrailingCommaInArguments:
   Enabled: false
 

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.6.0'.freeze
+    VERSION = '0.6.1'.freeze
   end
 end


### PR DESCRIPTION
Disable `Rails/HelperInstanceVariable` cop.

We have a lot of helpers that use instance variables, and it doesn't seem like we will ever get away from that. While it might be better to avoid using them in helpers, the cop just seems to add a lot of noise.