### PR TITLE
Fixes CN-205-11 - Upgrade to rubocop 1.1.

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -2,6 +2,7 @@
 require:
   - rubocop/rspec/focused
   - rubocop-rspec
+  - rubocop-rails
 
 AllCops:
   Exclude:

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.6.1'.freeze
+    VERSION = '0.7.0'.freeze
   end
 end

--- a/rubocop-aha.gemspec
+++ b/rubocop-aha.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.82.0'
+  spec.add_runtime_dependency 'rubocop', '>= 1.1'
 
   spec.add_dependency 'rubocop-rspec', '>= 1.25.1'
+  spec.add_dependency 'rubocop-rails', '>= 2.8.1'
   spec.add_dependency 'rubocop-rspec-focused', '>= 1.0.0'
 end


### PR DESCRIPTION
This can not be merged until some other dependencies are also upgraded to use rubocop 1.x.

Our main bottlenecks are capybara, erb_linter and pronto-rubocop.