### PR TITLE
Disable Style/MethodMissingSuper.

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -329,3 +329,6 @@ Style/HashTransformValues:
 
 Style/HashEachMethods:
   Enabled: true
+
+Style/MethodMissingSuper:
+  Enabled: false


### PR DESCRIPTION
Often we seem to want to use method_missing and specifically do not want
to call super because all calls are proxied.
