### PR TITLE
Disable Style/NegatedIf

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -335,3 +335,6 @@ Style/HashEachMethods:
 
 Style/MethodMissingSuper:
   Enabled: false
+
+Style/NegatedIf:
+  Enabled: false


### PR DESCRIPTION
This rule is oversensitive and often leads to less readable code. After running it through autofix and looking at the results, it seemed like a step backward. 

How if statements are written should be a call made based on context, and while we should be sensitive to negated ifs, an automated rule isn't the way to do it.