### PR TITLE
Don't enforce coercion convention for float division

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -338,3 +338,6 @@ Style/MethodMissingSuper:
 
 Style/NegatedIf:
   Enabled: false
+
+Style/FloatDivision:
+  Enabled: false


### PR DESCRIPTION
Do we need to enforce a style for float division? 

The default is to choose one side only. This could lead to bugs introduced by by unwittingly changing that side to be an integer and leading to an unwanted result. It would be better to require both sides coerced. 

Example failure:

```
xxxxx.rb:68:9: C: Style/FloatDivision: Prefer using .to_f on one side only.
      ((discount.to_f / total.to_f) * 100).round
```

This PR disables the cop as it seems unnecessary.

https://rubystyle.guide#float-division

By default robocop uses : single_coerce 

