### PR TITLE
Remove Rails/Delegate

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -257,7 +257,7 @@ Style/EachWithObject:
 
 Style/EmptyMethod:
   Enabled: false
-  
+
 Style/FormatStringToken:
   Enabled: false
 
@@ -340,4 +340,7 @@ Style/NegatedIf:
   Enabled: false
 
 Style/FloatDivision:
+  Enabled: false
+
+Rails/Delegate:
   Enabled: false


### PR DESCRIPTION
I think we should remove Rails/Delegate. The primary reason is that it makes searching for a method definition in a large codebase difficult.

```ruby
# Easier to search for - just search for `def bar`
def bar
  foo.bar
end

# Harder to search for because if you search for `bar` you also find all the times that `bar` is called
delegate :bar to: :foo
```

A potentially more compelling case is that it also makes the prefixed case far more obsure, and significantly harder to find.
```ruby
# Easy to search for. If I am looking for the definition of `foo_bar`, I can search for `def foo_bar`
def foo_bar
  foo.bar
end

# Impossible to search for the definition because `foo_bar` is only ever invoked, not defined.
delegate :bar, to: :foo, prefix: true
```