### PR TITLE
Remove MultilineMethodCallBraceLayout rules

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -82,9 +82,6 @@ Layout/MultilineArrayBraceLayout:
 Layout/MultilineHashBraceLayout:
   EnforcedStyle: new_line
 
-Layout/MultilineMethodCallBraceLayout:
-  EnforcedStyle: new_line
-
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented_relative_to_receiver
 


### PR DESCRIPTION
This cop prevents perfectly fine code from being accepted:

```
# rejected
method_call({
  key: value,
  key2: value2,
})

# accepted
method_call(
  {
    key: value,
    key2: value2,
  }
)
```

I think we might have similar issues with `Layout/MultilineArrayBraceLayout` and `Layout/MultilineHashBraceLayout`, but I'm not sure.