### PR TITLE
Disable Lint/AssignmentInCondition.

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -344,3 +344,6 @@ Style/FloatDivision:
 
 Rails/Delegate:
   Enabled: false
+
+Lint/AssignmentInCondition:
+  Enabled: false

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.6.1'.freeze
+    VERSION = '0.6.2'.freeze
   end
 end


### PR DESCRIPTION
This is a common pattern:
```
if some_var = true
  do_something
end
```

I'd prefer we were allowed to use this style than enforcing:
```
if (some_var = true)
  do_something
end
```