### PR TITLE
Disable Layout/MultilineArrayBraceLayout.

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -342,5 +342,8 @@ Style/NegatedIf:
 Style/FloatDivision:
   Enabled: false
 
+Layout/MultilineArrayBraceLayout:
+  Enabled: false
+
 Rails/Delegate:
   Enabled: false

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.6.1'.freeze
+    VERSION = '0.6.3'.freeze
   end
 end

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.6.3'.freeze
+    VERSION = '0.6.7'.freeze
   end
 end


### PR DESCRIPTION
The general consensus appears to be https://github.com/aha-app/rubocop-aha/pull/70 should be disabled, so we should also then disable MultilineArrayBraceLayout.

Link: https://docs.rubocop.org/rubocop/cops_layout.html#layoutmultilinearraybracelayout