### PR TITLE
Disable Naming/AccessorMethodNames

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -145,6 +145,9 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Enabled: false
 
+Naming/AccessorMethodName:
+  Enabled: false
+
 Naming/MethodParameterName:
   MinNameLength: 2
   AllowedNames: _


### PR DESCRIPTION
The prefixes `get_` and `set_` are not necessarily for object attributes.

- `get` can mean fetching/loading something from a remote resource
- `set` can mean pushing/storing a value

It doesn't make sense to invent aliases for these common procedures. Whether
they are actually attributes or not is irrelevant, and these names should be
allowed where they make sense.

This rule adds no value.