### PR TITLE
Disable Style/CommentAnnotation

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -252,6 +252,9 @@ Style/ClassAndModuleChildren:
 Style/ClassCheck:
   Enabled: false
 
+Style/CommentAnnotation:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.6.1'.freeze
+    VERSION = '0.6.5'.freeze
   end
 end


### PR DESCRIPTION
This is not a particularly important rule, and fixing instances of it in the codebase also makes it harder to know who wrote any existing incorrectly formatted comments. Just...don't search for `TODO:` specifically and everything will be fine.