### PR TITLE
Cn 882 missing super

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -300,7 +300,7 @@ Style/IfUnlessModifier:
 Style/Lambda:
   EnforcedStyle: literal
 
-Style/MethodMissingSuper:
+Style/MissingSuper:
   Enabled: false
 
 Style/MultilineBlockChain:

--- a/lib/config.yml
+++ b/lib/config.yml
@@ -106,7 +106,7 @@ Layout/TrailingWhitespace:
 Layout/SpaceAroundMethodCallOperator:
   Enabled: true
 
-Lint/MethodMissingSuper:
+Lint/MissingSuper:
   Enabled: false
 
 Lint/InheritException:
@@ -302,9 +302,6 @@ Style/IfUnlessModifier:
 
 Style/Lambda:
   EnforcedStyle: literal
-
-Style/MissingSuper:
-  Enabled: false
 
 Style/MultilineBlockChain:
   Enabled: false

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.7.0'.freeze
+    VERSION = '0.7.1'.freeze
   end
 end


### PR DESCRIPTION
We want `Lint/MissingSuper`, not `Lint/MethodMissingSuper`.

https://github.com/rubocop-hq/rubocop/blob/5f27629e438952bdbc05d84cf3951f429ec2556e/config/obsoletion.yml#L76-L79