### PR TITLE
Disable Lint/RedundantSplatExpansion

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -121,6 +121,9 @@ Lint/UnusedMethodArgument:
 Lint/RaiseException:
   Enabled: true
 
+Lint/RedundantSplatExpansion:
+  Enabled: false
+
 Lint/StructNewOverride:
   Enabled: true
 
@@ -167,7 +170,7 @@ Naming/RescuedExceptionsVariableName:
 # Allow ad-hoc test models to use bare ActiveRecord::Base
 Rails/ApplicationRecord:
   Exclude:
-    - "spec/**/*.rb"
+    - 'spec/**/*.rb'
 
 Rails/Delegate:
   Enabled: false
@@ -178,7 +181,7 @@ Rails/HttpPositionalArguments:
 # Allow ad-hoc test models to be referenced by class instance
 Rails/ReflectionClassName:
   Exclude:
-    - "spec/**/*.rb"
+    - 'spec/**/*.rb'
 
 Rails/RequestReferer:
   EnforcedStyle: referrer


### PR DESCRIPTION
If we upgrade to 1.7.0, we can re-enable this to use the `AllowPercentLiteralArrayArgument` option.

The main reason to disable this is to allow splatting for `%` literals, e.g. `slice(*%w[foo bar])`.