### PR TITLE
Fixes CN-883 - Disable RSpec/MultipleMemoizedHelpers.

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -228,6 +228,9 @@ RSpec/MessageSpies:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 RSpec/NestedGroups:
   Enabled: false
 

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.7.1'.freeze
+    VERSION = '0.7.2'.freeze
   end
 end


### PR DESCRIPTION
Disable https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecmultiplememoizedhelpers.

I think this is fairly arbitrary and I'd rather we disable it for now.