### PR TITLE
Use arguements in FilePath

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -173,7 +173,7 @@ Rails/Delegate:
   Enabled: false
 
 Rails/FilePath:
-  EnforcedStyle: arguments
+  Enabled: false
   
 Rails/HttpPositionalArguments:
   Enabled: false

--- a/lib/config.yml
+++ b/lib/config.yml
@@ -172,6 +172,9 @@ Rails/ApplicationRecord:
 Rails/Delegate:
   Enabled: false
 
+Rails/FilePath:
+  EnforcedStyle: arguments
+  
 Rails/HttpPositionalArguments:
   Enabled: false
 

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.7.2'.freeze
+    VERSION = '0.7.4'.freeze
   end
 end


### PR DESCRIPTION
Pretty sure we will never use windows but arguments allows the underlying system to generate the path correctly. Do not force the developer to write paths.

This does impact absolute paths:
https://github.com/rubocop-hq/rubocop-rails/issues/195#issuecomment-580412005
