### PR TITLE
Cn 817 upgrade rubocop 1 1 0

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -1,7 +1,8 @@
 ---
 require:
-  - rubocop/rspec/focused
   - rubocop-rspec
+  - rubocop-rails
+
 
 AllCops:
   Exclude:

--- a/lib/rubocop-aha/version.rb
+++ b/lib/rubocop-aha/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Aha
-    VERSION = '0.7.4'.freeze
+    VERSION = '0.8.0'.freeze
   end
 end

--- a/rubocop-aha.gemspec
+++ b/rubocop-aha.gemspec
@@ -20,9 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.93.0'
-
-  spec.add_dependency 'rubocop-rspec', '>= 1.39.0'
-  spec.add_dependency 'rubocop-rails', '>= 2.5.2'
-  spec.add_dependency 'rubocop-rspec-focused', '>= 1.0.0'
+  spec.add_dependency 'rubocop', '>= 1.1.0'
+  spec.add_dependency 'rubocop-rspec', '>= 1.39'
+  spec.add_dependency 'rubocop-rails', '>= 2.8'
 end

--- a/rubocop-aha.gemspec
+++ b/rubocop-aha.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rubocop', '>= 1.1.0'
-  spec.add_dependency 'rubocop-rspec', '>= 1.39'
-  spec.add_dependency 'rubocop-rails', '>= 2.8'
+  spec.add_dependency 'rubocop-rspec', '>= 2.2.0'
+  spec.add_dependency 'rubocop-rails', '>= 2.9.1'
 end


### PR DESCRIPTION
…ocop-rspec-focused dependency.

Upgrade to rubocop 1.1.0.  This also cleans up the gemfile to remove the now very old `rubocop-rspec-focused`, which was [replaced](https://github.com/lovewithfood/rubocop-rspec-focused#rubocop-rspec-focused) by `rubocop-rspec`.