### PR TITLE
Allow defining tasks without application dependencies

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -179,6 +179,10 @@ Rails/FilePath:
 Rails/HttpPositionalArguments:
   Enabled: false
 
+# Allow defining tasks that don't depend on loading the Rails app
+Rails/RakeEnvironment:
+  Enabled: false
+
 # Allow ad-hoc test models to be referenced by class instance
 Rails/ReflectionClassName:
   Exclude:


### PR DESCRIPTION
Not all tasks need to wait for Rails to be loaded.