### PR TITLE
Disable Style/OptionalBooleanParameter rule

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -337,6 +337,9 @@ Style/NumericLiterals:
 Style/NumericPredicate:
   Enabled: false
 
+Style/OptionalBooleanParameter:
+  Enabled: false
+
 Style/ParallelAssignment:
   Enabled: false
 


### PR DESCRIPTION
[This cop](https://docs.rubocop.org/rubocop/cops_style.html#styleoptionalbooleanparameter) will complain about code like
`def method(param = false)`

It would rather we do
`def method(param: false)`

Thing is, we use the first ("bad") pattern *a lot*. It's also an unsafe one to try to fix because it affects anything that calls the method in question. Even if the intent is to prevent future use, any child classes of existing uses will have to implement it, and then Rubocop will get upset. At this point, I believe we should not enforce this style because of how common the behavior already is in the codebase, and the inherent danger in trying to fix existing code to comply with the Rubocop rule.